### PR TITLE
Nickname parsing improvements

### DIFF
--- a/app/src/androidTest/java/com/pokerio/app/SettingsInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/pokerio/app/SettingsInstrumentedTest.kt
@@ -202,4 +202,63 @@ class SettingsInstrumentedTest {
             .assertRangeInfoEquals(ProgressBarRangeInfo(current = 1.0f, range = 0.0f..1.0f, steps = 0))
         androidTestRule.onNodeWithTag("slider_text").assert(hasText("20"))
     }
+
+    @Test
+    fun newlineNicknameTest() {
+        val testNickname = "test"
+
+        val context = androidTestRule.activity
+        val sharedPreferences = context.getSharedPreferences(
+            context.getString(R.string.shared_preferences_file),
+            Context.MODE_PRIVATE
+        )
+
+        androidTestRule.activity.setContent {
+            SettingsScreen(navigateBack = {})
+        }
+
+        val textField = androidTestRule.onNodeWithTag("settings_nickname")
+        textField.assertExists()
+        textField.assertIsDisplayed()
+        textField.performTextReplacement("$testNickname\n")
+
+        val backButton = androidTestRule.onNodeWithTag("settings_back")
+        backButton.performClick()
+
+        val newNickname = sharedPreferences.getString(
+            context.getString(R.string.sharedPreferences_nickname),
+            ""
+        )
+        assert(newNickname == testNickname)
+    }
+
+    @Test
+    fun newlineNickname2Test() {
+        val testNickname = "test\n\ntest"
+        val correctNickname = "testtest"
+
+        val context = androidTestRule.activity
+        val sharedPreferences = context.getSharedPreferences(
+            context.getString(R.string.shared_preferences_file),
+            Context.MODE_PRIVATE
+        )
+
+        androidTestRule.activity.setContent {
+            SettingsScreen(navigateBack = {})
+        }
+
+        val textField = androidTestRule.onNodeWithTag("settings_nickname")
+        textField.assertExists()
+        textField.assertIsDisplayed()
+        textField.performTextReplacement(testNickname)
+
+        val backButton = androidTestRule.onNodeWithTag("settings_back")
+        backButton.performClick()
+
+        val newNickname = sharedPreferences.getString(
+            context.getString(R.string.sharedPreferences_nickname),
+            ""
+        )
+        assert(newNickname == correctNickname)
+    }
 }

--- a/app/src/androidTest/java/com/pokerio/app/SettingsInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/pokerio/app/SettingsInstrumentedTest.kt
@@ -205,7 +205,8 @@ class SettingsInstrumentedTest {
 
     @Test
     fun newlineNicknameTest() {
-        val testNickname = "test"
+        val testNickname = "test\n"
+        val correctNickname = "test"
 
         val context = androidTestRule.activity
         val sharedPreferences = context.getSharedPreferences(
@@ -220,7 +221,7 @@ class SettingsInstrumentedTest {
         val textField = androidTestRule.onNodeWithTag("settings_nickname")
         textField.assertExists()
         textField.assertIsDisplayed()
-        textField.performTextReplacement("$testNickname\n")
+        textField.performTextReplacement(testNickname)
 
         val backButton = androidTestRule.onNodeWithTag("settings_back")
         backButton.performClick()
@@ -229,13 +230,13 @@ class SettingsInstrumentedTest {
             context.getString(R.string.sharedPreferences_nickname),
             ""
         )
-        assert(newNickname == testNickname)
+        assert(newNickname == correctNickname)
     }
 
     @Test
     fun newlineNickname2Test() {
         val testNickname = "test\n\ntest"
-        val correctNickname = "testtest"
+        val correctNickname = "test test"
 
         val context = androidTestRule.activity
         val sharedPreferences = context.getSharedPreferences(

--- a/app/src/main/java/com/pokerio/app/screens/InitialSetupScreen.kt
+++ b/app/src/main/java/com/pokerio/app/screens/InitialSetupScreen.kt
@@ -49,6 +49,8 @@ fun InitialSetupScreen(
     }
 
     val onContinue = {
+        nickname = nickname.filterNot { it == '\n' }
+
         with(sharedPreferences.edit()) {
             putString(nicknameSharedKey, nickname)
             apply()
@@ -75,7 +77,8 @@ fun InitialSetupScreen(
                 if (!nicknameCorrect) {
                     Text(stringResource(id = R.string.nickname_error))
                 }
-            }
+            },
+            singleLine = true
         )
         IconButton(
             onClick = { onContinue() },

--- a/app/src/main/java/com/pokerio/app/screens/InitialSetupScreen.kt
+++ b/app/src/main/java/com/pokerio/app/screens/InitialSetupScreen.kt
@@ -49,7 +49,7 @@ fun InitialSetupScreen(
     }
 
     val onContinue = {
-        nickname = nickname.filterNot { it == '\n' }
+        nickname = Player.fixNickname(nickname)
 
         with(sharedPreferences.edit()) {
             putString(nicknameSharedKey, nickname)

--- a/app/src/main/java/com/pokerio/app/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/pokerio/app/screens/SettingsScreen.kt
@@ -106,6 +106,8 @@ fun SettingsScreen(
 
     val onNavigateBack = {
         // Update shared preferences values on exit
+        nickname = nickname.filterNot { it == '\n' }
+
         with(sharedPreferences.edit()) {
             if (nicknameCorrect) {
                 putString(nicknameSharedKey, nickname)
@@ -182,7 +184,8 @@ fun SettingsScreen(
                         if (!nicknameCorrect) {
                             Text(stringResource(id = R.string.nickname_error))
                         }
-                    }
+                    },
+                    singleLine = true
                 )
             }
             Spacer(modifier = spacerModifier)

--- a/app/src/main/java/com/pokerio/app/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/pokerio/app/screens/SettingsScreen.kt
@@ -106,7 +106,7 @@ fun SettingsScreen(
 
     val onNavigateBack = {
         // Update shared preferences values on exit
-        nickname = nickname.filterNot { it == '\n' }
+        nickname = Player.fixNickname(nickname)
 
         with(sharedPreferences.edit()) {
             if (nicknameCorrect) {

--- a/app/src/main/java/com/pokerio/app/utils/Player.kt
+++ b/app/src/main/java/com/pokerio/app/utils/Player.kt
@@ -23,7 +23,7 @@ class Player(
             returnNickname = returnNickname.trimEnd(' ')
             returnNickname = returnNickname.trimStart(' ')
             // Do not allow double spaces
-            returnNickname = returnNickname.replace("  ", " ")
+            returnNickname = returnNickname.replace(Regex("\\s+"), " ")
 
             return returnNickname
         }

--- a/app/src/main/java/com/pokerio/app/utils/Player.kt
+++ b/app/src/main/java/com/pokerio/app/utils/Player.kt
@@ -15,5 +15,17 @@ class Player(
         fun validateNickname(nickname: String): Boolean {
             return nickname.isNotBlank() && nickname.length <= MAX_NICKNAME_LEN
         }
+
+        fun fixNickname(nickname: String): String {
+            // Do not allow newlines
+            var returnNickname = nickname.replace('\n', ' ')
+            // Do not allow trailing and leading spaces
+            returnNickname = returnNickname.trimEnd(' ')
+            returnNickname = returnNickname.trimStart(' ')
+            // Do not allow double spaces
+            returnNickname = returnNickname.replace("  ", " ")
+
+            return returnNickname
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,10 +17,10 @@
     <string name="nickname">Nickname</string>
     <string name="starting_funds">Starting funds</string>
     <string name="small_blind">Small blind</string>
-    <string name="nickname_error">Nickname should be between 1 and 20 characters long</string>
+    <string name="nickname_error">Requires 1 to 20 characters</string>
     <string name="failed_update">Failed to update settings</string>
     <string name="camara_credit">Thanks to Arthur Camara, who\'s work our card suit graphics are based on!</string>
-    <string name="camara_link"></string>
+    <string name="camara_link">https://arthurcamara.co/</string>
 
     <!-- Lobby screen -->
     <string name="players">Players</string>

--- a/app/src/test/java/com/pokerio/app/PlayerTests.kt
+++ b/app/src/test/java/com/pokerio/app/PlayerTests.kt
@@ -20,4 +20,30 @@ class PlayerTests {
         assert(!Player.validateNickname(""))
         assert(!Player.validateNickname("     "))
     }
+
+    @Test
+    fun fixIncorrectNickname() {
+        val incorrect1 = "test\n"
+        val correct1 = "test"
+        val incorrect2 = "test   "
+        val correct2 = "test"
+        val incorrect3 = "     test"
+        val correct3 = "test"
+        val incorrect4 = "test\n\n"
+        val correct4 = "test"
+        val incorrect5 = "\n\ntest"
+        val correct5 = "test"
+        val incorrect6 = "te\n\nst"
+        val correct6 = "te st"
+        val incorrect7 = "te    st"
+        val correct7 = "te st"
+
+        assert(Player.fixNickname(incorrect1) == correct1)
+        assert(Player.fixNickname(incorrect2) == correct2)
+        assert(Player.fixNickname(incorrect3) == correct3)
+        assert(Player.fixNickname(incorrect4) == correct4)
+        assert(Player.fixNickname(incorrect5) == correct5)
+        assert(Player.fixNickname(incorrect6) == correct6)
+        assert(Player.fixNickname(incorrect7) == correct7)
+    }
 }


### PR DESCRIPTION
Previously, we allowed newline characters in nicknames. Now they are automatically replaced with spaces if input. We also don't allow multiple consecutive spaces. The keyboard doesn't show the newline button and instead shows a button to end entry.